### PR TITLE
Merge feature/keep-utc- time into develop

### DIFF
--- a/VelodyneHDL/IO/GPS-IMU/Common/NMEAParser.cxx
+++ b/VelodyneHDL/IO/GPS-IMU/Common/NMEAParser.cxx
@@ -43,13 +43,15 @@ namespace {
     time_t epochtime;
 
     t.tm_year = 2000-1900+location.DateYear;
-    t.tm_mon = location.DateMonth-1;
+    t.tm_mon = location.DateMonth-1; //tm_mom expects 0-11
     t.tm_mday = location.DateDay;
     t.tm_hour = location.HH;
     t.tm_min = location.MM;
     t.tm_sec = location.SS;
 
     epochtime = timegm(&t);
+
+    location.UnixTime = epochtime;
   }
 
   bool ParseFAA(const std::vector<std::string>& w,
@@ -353,6 +355,8 @@ bool NMEAParser::ParseGPRMC(const std::vector<std::string>& w,
   {
     return false;
   }
+
+  SetUnixTime(location);
 
   return true;
 }

--- a/VelodyneHDL/IO/GPS-IMU/Common/NMEAParser.cxx
+++ b/VelodyneHDL/IO/GPS-IMU/Common/NMEAParser.cxx
@@ -38,7 +38,7 @@ namespace {
     return true;
   }
 
-  bool SetUnixTime(NMEALocation& location) {
+  bool SetHourUnixTime(NMEALocation& location) {
     struct tm t;
     time_t epochtime;
 
@@ -46,12 +46,12 @@ namespace {
     t.tm_mon = location.DateMonth-1; //tm_mom expects 0-11
     t.tm_mday = location.DateDay;
     t.tm_hour = location.HH;
-    t.tm_min = location.MM;
-    t.tm_sec = location.SS;
+    t.tm_min = 0;
+    t.tm_sec = 0;
 
     epochtime = timegm(&t);
 
-    location.UnixTime = epochtime;
+    location.HourUnixTime = epochtime;
   }
 
   bool ParseFAA(const std::vector<std::string>& w,
@@ -356,7 +356,7 @@ bool NMEAParser::ParseGPRMC(const std::vector<std::string>& w,
     return false;
   }
 
-  SetUnixTime(location);
+  SetHourUnixTime(location);
 
   return true;
 }

--- a/VelodyneHDL/IO/GPS-IMU/Common/NMEAParser.cxx
+++ b/VelodyneHDL/IO/GPS-IMU/Common/NMEAParser.cxx
@@ -23,19 +23,33 @@ namespace {
       std::modf(read, &integral_part);
       double fractional_part = read - integral_part;
       int HHMMSS = static_cast<int>(vtkMath::Round(integral_part));
-      int SS = HHMMSS % 100;
-      int MM = ((HHMMSS - SS) % 10000) / 100;
-      int HH = (HHMMSS - SS - 100 * MM) / 10000;
+      location.SS = HHMMSS % 100;
+      location.MM = ((HHMMSS - location.SS) % 10000) / 100;
+      location.HH = (HHMMSS - location.SS - 100 * location.MM) / 10000;
       location.UTCSecondsOfDay =
           fractional_part
-          + static_cast<double>(SS)
-          + 60.0 * static_cast<double>(MM)
-          + 3600.0 * static_cast<double>(HH);
+          + static_cast<double>(location.SS)
+          + 60.0 * static_cast<double>(location.MM)
+          + 3600.0 * static_cast<double>(location.HH);
     }
     catch (const std::logic_error&) {
       return false;
     }
     return true;
+  }
+
+  bool SetUnixTime(NMEALocation& location) {
+    struct tm t;
+    time_t epochtime;
+
+    t.tm_year = 2000-1900+location.DateYear;
+    t.tm_mon = location.DateMonth-1;
+    t.tm_mday = location.DateDay;
+    t.tm_hour = location.HH;
+    t.tm_min = location.MM;
+    t.tm_sec = location.SS;
+
+    epochtime = timegm(&t);
   }
 
   bool ParseFAA(const std::vector<std::string>& w,

--- a/VelodyneHDL/IO/GPS-IMU/Common/NMEAParser.h
+++ b/VelodyneHDL/IO/GPS-IMU/Common/NMEAParser.h
@@ -122,6 +122,10 @@ public:
   double Lat;
   double Long;
   double UTCSecondsOfDay;
+  double UnixTime;
+  int SS;
+  int MM;
+  int HH;
   bool HasAltitude;
   double Altitude;
   bool HasGeoidalSeparation;

--- a/VelodyneHDL/IO/GPS-IMU/Common/NMEAParser.h
+++ b/VelodyneHDL/IO/GPS-IMU/Common/NMEAParser.h
@@ -122,7 +122,7 @@ public:
   double Lat;
   double Long;
   double UTCSecondsOfDay;
-  double UnixTime;
+  double HourUnixTime;
   int SS;
   int MM;
   int HH;

--- a/VelodyneHDL/IO/GPS-IMU/Velodyne/vtkVelodyneHDLPositionReader.cxx
+++ b/VelodyneHDL/IO/GPS-IMU/Velodyne/vtkVelodyneHDLPositionReader.cxx
@@ -496,7 +496,7 @@ int vtkVelodyneHDLPositionReader::RequestData(vtkInformation* vtkNotUsed(request
   gpsTime->SetName("gpstime");
 
   vtkSmartPointer<vtkDoubleArray> unixTime = vtkSmartPointer<vtkDoubleArray>::New();
-  unixTime->SetName("unixtime");
+  unixTime->SetName("hourUnixTime");
 
   typedef std::map<std::string, vtkSmartPointer<vtkDoubleArray> > VecMap;
   VecMap dataVectors;
@@ -539,7 +539,7 @@ int vtkVelodyneHDLPositionReader::RequestData(vtkInformation* vtkNotUsed(request
   double GPSTimeOffset = 0.0;
   double convertedGPSUpdateTime = 0.0;
 
-  double utcToUnixTime = 0.0;
+  double hourUtcToUnixTime = 0.0;
 
   bool hasLastLidarUpdateTime = false;
   double lastLidarUpdateTime = 0.0;
@@ -670,7 +670,7 @@ int vtkVelodyneHDLPositionReader::RequestData(vtkInformation* vtkNotUsed(request
 	heading = 0.0;
       }
 
-      utcToUnixTime = parsedNMEA.UnixTime;
+      hourUtcToUnixTime = parsedNMEA.HourUnixTime;
       gpsUpdateTime = parsedNMEA.UTCSecondsOfDay; //incorrect so made the decision to move to Unix time
       if (!hasLastGPSUpdateTime)
       {
@@ -726,7 +726,7 @@ int vtkVelodyneHDLPositionReader::RequestData(vtkInformation* vtkNotUsed(request
     lats->InsertNextValue(lat);
     lons->InsertNextValue(lon);
     gpsTime->InsertNextValue(convertedGPSUpdateTime);
-    unixTime->InsertNextValue(utcToUnixTime);
+    unixTime->InsertNextValue(hourUtcToUnixTime);
     polyIds->InsertNextId(pointcount);
 
     times->InsertNextValue(convertedLidarUpdateTime);

--- a/VelodyneHDL/IO/Lidar/Common/vtkLidarPacketInterpreter.h
+++ b/VelodyneHDL/IO/Lidar/Common/vtkLidarPacketInterpreter.h
@@ -131,6 +131,8 @@ public:
 
   virtual double ComputeGpsTopOfHourTime() { return 0; }
 
+  virtual double ComputeUTCTopOfHourTime() { return 0; }
+
   virtual bool GetShouldValidateCalibrationFromStream() { return true; }
 
   virtual bool ValidateCalibrationFromLiveStream(bool checkIncompleteCycles) {return false;}

--- a/VelodyneHDL/IO/Lidar/Common/vtkLidarReader.cxx
+++ b/VelodyneHDL/IO/Lidar/Common/vtkLidarReader.cxx
@@ -82,6 +82,7 @@ int vtkLidarReader::ReadFrameInformation()
   }
 
   this->GpsTopOfHourTime = this->Interpreter->ComputeGpsTopOfHourTime();
+  this->UTCTopOfHourTime = this->Interpreter->ComputeUTCTopOfHourTime();
 
   return this->GetNumberOfFrames();
 }

--- a/VelodyneHDL/IO/Lidar/Common/vtkLidarReader.h
+++ b/VelodyneHDL/IO/Lidar/Common/vtkLidarReader.h
@@ -73,6 +73,7 @@ public:
   vtkSetMacro(ShowFirstAndLastFrame, bool)
 
   vtkGetMacro(GpsTopOfHourTime, double)
+  vtkGetMacro(UTCTopOfHourTime, double)
 
 protected:
   vtkLidarReader() = default;
@@ -98,6 +99,7 @@ protected:
 
   // gpsTopOfHourTime for when position packets are not used
   double GpsTopOfHourTime;
+  double UTCTopOfHourTime;
 
 private:
   /**

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.h
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.h
@@ -60,6 +60,8 @@ public:
     double focalSlope[HDL_MAX_NUM_LASERS], double minIntensity[HDL_MAX_NUM_LASERS],
     double maxIntensity[HDL_MAX_NUM_LASERS]);
 
+  double ComputeUTCTopOfHourTime();
+
   double ComputeGpsTopOfHourTime();
 
   bool ValidateCalibrationFromLiveStream(bool checkIncompleteCycles); // make this over rides the base funciton


### PR DESCRIPTION
This feature branch:

VLS 128:
- Computes the top of hour UTC (Unix) time from the NMEA sentence we get from telemetry packets
- The code from Kitware only computed the seconds of the day, which was incorrect

HDL 64
- The time values are streamed in for this velodyne case
- Instead of a convoluted method that we previously had to convert the UTC top of hour time to GPS time, we have a simple method now to return UTC (unix) top of hour time
  - That previous method was convoluted because we used to handle leap seconds on our own. Now we don't have to.