### PR TITLE
Merge jklimov/dual-plus-confidence into develop

### DIFF
--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkDataPacket.h
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkDataPacket.h
@@ -244,17 +244,17 @@ struct HDLDataPacket
 
   inline bool isDPCReturnVLS128() const { return factoryField1 == DUAL_PLUS_CONFIDENCE; }
 
-  inline bool isFirstBlockOfDPCPacket128() const
+  inline bool isFirstBlockOfDPCPacket128(const int firingBlock) const
   {
     return isDPCReturnVLS128() && (firingBlock % 3 == 0); 
   }
 
-  inline bool isSecondBlockOfDPCPacket128() const
+  inline bool isSecondBlockOfDPCPacket128(const int firingBlock) const
   {
     return isDPCReturnVLS128() && (firingBlock % 3 == 1);
   }
 
-  inline bool isConfidenceBlockOfDPCPacket128() const
+  inline bool isConfidenceBlockOfDPCPacket128(const int firingBlock) const
   {
     return isDPCReturnVLS128() && (firingBlock % 3 == 2);
   }

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkDataPacket.h
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkDataPacket.h
@@ -235,8 +235,9 @@ struct HDLDataPacket
   inline bool isDualReturnFiringBlock(const int firingBlock) const
   {
     if (isVLS128())
-      return isDualModeReturnVLS128() && isDualBlockOfDualPacket128(firingBlock);
-    if (isHDL64())
+      return (isDualModeReturnVLS128() && isDualBlockOfDualPacket128(firingBlock)) ||
+             (isDPCReturnVLS128() && isSecondBlockOfDPCPacket128(firingBlock));
+    else if (isHDL64())
       return isDualModeReturnHDL64() && isDualBlockOfDualPacket64(firingBlock);
     else
       return isDualModeReturn16Or32() && isDualBlockOfDualPacket16Or32(firingBlock);

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkDataPacket.h
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkDataPacket.h
@@ -234,9 +234,10 @@ struct HDLDataPacket
 
   inline bool isDualReturnFiringBlock(const int firingBlock) const
   {
-    if (isVLS128())
-      return (isDualModeReturnVLS128() && isDualBlockOfDualPacket128(firingBlock)) ||
-             (isDPCReturnVLS128() && isSecondBlockOfDPCPacket128(firingBlock));
+    if (isVLS128()) {
+      return ((isDualModeReturnVLS128() && isDualBlockOfDualPacket128(firingBlock)) ||
+             (isDPCReturnVLS128() && isSecondBlockOfDPCPacket128(firingBlock)));
+    }
     else if (isHDL64())
       return isDualModeReturnHDL64() && isDualBlockOfDualPacket64(firingBlock);
     else
@@ -275,7 +276,7 @@ struct HDLDataPacket
 
   inline int getRotationalDiffForVLS128(int firingBlock) const
   {
-    if (static_cast<DualReturnSensorMode>(factoryField1) == DUAL_RETURN)
+    if (static_cast<DualReturnSensorMode>(factoryField1) == DUAL_RETURN || static_cast<DualReturnSensorMode>(factoryField1) == DUAL_PLUS_CONFIDENCE)
     {
       if (firingBlock > 6)
         firingBlock = 6;

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkDataPacket.h
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkDataPacket.h
@@ -118,6 +118,7 @@ enum DualReturnSensorMode
   STRONGEST_RETURN = 0x37,
   LAST_RETURN = 0x38,
   DUAL_RETURN = 0x39,
+  DUAL_PLUS_CONFIDENCE = 0x3B,
 };
 
 static inline std::string DualReturnSensorModeToString(DualReturnSensorMode type)
@@ -130,6 +131,8 @@ static inline std::string DualReturnSensorModeToString(DualReturnSensorMode type
       return "LAST RETURN";
     case DualReturnSensorMode::DUAL_RETURN:
       return "DUAL RETURN";
+    case DualReturnSensorMode::DUAL_PLUS_CONFIDENCE:
+      return "DUAL PLUS CONFIDENCE";
     default:
       return "Unkown";
   }
@@ -237,6 +240,23 @@ struct HDLDataPacket
       return isDualModeReturnHDL64() && isDualBlockOfDualPacket64(firingBlock);
     else
       return isDualModeReturn16Or32() && isDualBlockOfDualPacket16Or32(firingBlock);
+  }
+
+  inline bool isDPCReturnVLS128() const { return factoryField1 == DUAL_PLUS_CONFIDENCE; }
+
+  inline bool isFirstBlockOfDPCPacket128() const
+  {
+    return isDPCReturnVLS128() && (firingBlock % 3 == 0); 
+  }
+
+  inline bool isSecondBlockOfDPCPacket128() const
+  {
+    return isDPCReturnVLS128() && (firingBlock % 3 == 1);
+  }
+
+  inline bool isConfidenceBlockOfDPCPacket128() const
+  {
+    return isDPCReturnVLS128() && (firingBlock % 3 == 2);
   }
 
   inline static bool isDualBlockOfDualPacket128(const int firingBlock)

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
@@ -787,7 +787,7 @@ void vtkVelodynePacketInterpreter::ProcessPacket(unsigned char const * data, uns
   // assert(azimuthDiff > 0);
 
   // Add DualReturn-specific arrays if newly detected dual return packet
-  if (dataPacket->isDualModeReturn() && !this->HasDualReturn)
+  if ((dataPacket->isDualModeReturn() || dataPacket->isDPCReturnVLS128()) && !this->HasDualReturn)
   {
     this->HasDualReturn = true;
     this->CurrentFrame->GetPointData()->AddArray(this->DistanceFlag.GetPointer());
@@ -864,7 +864,7 @@ void vtkVelodynePacketInterpreter::ProcessPacket(unsigned char const * data, uns
     if (this->FiringsSkip == 0 || firingBlock % (this->FiringsSkip + 1) == 0)
     {
       this->ProcessFiring(firingData, multiBlockLaserIdOffset, firingBlock, azimuthDiff, timestamp,
-        rawtime, dataPacket->isDualReturnFiringBlock(firingBlock), dataPacket->isDualModeReturn(), confidenceValues);
+        rawtime, dataPacket->isDualReturnFiringBlock(firingBlock), dataPacket->isDualModeReturn() || dataPacket->isDPCReturnVLS128(), confidenceValues);
     }
   }
 }

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
@@ -1436,23 +1436,23 @@ void vtkVelodynePacketInterpreter::PreProcessPacket(unsigned char const * data, 
   {
     const HDLFiringData& firingData = dataPacket->firingData[i];
 
-    if (isDPCReturnVLS128() && !isConfidenceBlockOfDPCPacket128())
+    if (dataPacket->isDPCReturnVLS128() && !dataPacket->isConfidenceBlockOfDPCPacket128(i))
     {
       uint16_t confidenceValues[HDL_LASER_PER_FIRING];
 
       // The confidence block is two blocks away from the first firing block, and one block away from the second
-      int offset = isFirstBlockOfDPCPacket128() ? 2 : 1;
+      int offset = dataPacket->isFirstBlockOfDPCPacket128(i) ? 2 : 1;
 
       for (int j = 0; j < HDL_LASER_PER_FIRING; ++j)
       {
         // First block corresponds to the latter half (12 bits) of confidence data (see VLS-128 manual pg. 59)
-        if (isFirstBlockOfDPCPacket128())
+        if (dataPacket->isFirstBlockOfDPCPacket128(i))
         {
           // Select last 4 bits of distance, left shift by 12 bits, then | with 8 bits of intensity left shifted by 4 bits
           confidenceValues[j] = (dataPacket->firingData[i + offset].laserReturns[j].distance & 0x000f << 12) |
               dataPacket->firingData[i + offset].laserReturns[j].intensity << 4;
         }
-        else if (isSecondBlockOfDPCPacket128())
+        else if (dataPacket->isSecondBlockOfDPCPacket128(i))
         {
           // Second firing block confidence data is the first 12 bits of distance
           confidenceValues[j] = dataPacket->firingData[i + offset].laserReturns[j].distance & 0xfff0;
@@ -1461,7 +1461,7 @@ void vtkVelodynePacketInterpreter::PreProcessPacket(unsigned char const * data, 
         // Sanity check (last 4 bits of confidenceValues[j] should always be empty)
         if (confidenceValues[j] & 0x000f != 0)
         {
-          std::cout << "Confidence data arithmetic error" << std::endl;
+          std::cerr << "Confidence data arithmetic error" << std::endl;
         }
       }
     }
@@ -1490,7 +1490,7 @@ void vtkVelodynePacketInterpreter::PreProcessPacket(unsigned char const * data, 
     }
 
     // Do not add confidence blocks if we are in DPC mode
-    if (currentFrameState.hasChangedWithValue(firingData) && !isConfidenceBlockOfDPCPacket128())
+    if (currentFrameState.hasChangedWithValue(firingData) && !dataPacket->isConfidenceBlockOfDPCPacket128(i))
     {
       // Add file position if the frame is not empty
       if (!isEmptyFrame || !this->IgnoreEmptyFrames)

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
@@ -1001,8 +1001,8 @@ void vtkVelodynePacketInterpreter::ProcessFiring(const HDLFiringData *firingData
   }
 }
 
-static double totalCount = 0.0;
-static double testCount = 0.0;
+//static double totalCount = 0.0;
+//static double testCount = 0.0;
 
 //-----------------------------------------------------------------------------
 void vtkVelodynePacketInterpreter::PushFiringData(unsigned char laserId, unsigned char rawLaserId,
@@ -1034,15 +1034,15 @@ void vtkVelodynePacketInterpreter::PushFiringData(unsigned char laserId, unsigne
   if (this->shouldBeCroppedOut(pos, static_cast<double>(azimuth) / 100.0))
     return;
 
-  totalCount++;
+  /*totalCount++;
   if (int(totalCount) % 10000 == 0) {
-    //std::cout << "total count: " << totalCount << ", test count: " << testCount << ", ratio: " << (testCount/totalCount) << std::endl;
-  }
+    std::cout << "total count: " << totalCount << ", test count: " << testCount << ", ratio: " << (testCount/totalCount) << std::endl;
+  }*/
 
   // Do not add any data before here as this might short-circuit
   if (isFiringDualReturnData)
   {
-    testCount++;
+    //testCount++;
     const vtkIdType dualPointId = this->LastPointId[rawLaserId];
     if (dualPointId < this->FirstPointIdOfDualReturnPair)
     {

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
@@ -1001,21 +1001,12 @@ void vtkVelodynePacketInterpreter::ProcessFiring(const HDLFiringData *firingData
   }
 }
 
-//static double totalCount = 0.0;
-//static double testCount = 0.0;
-
 //-----------------------------------------------------------------------------
 void vtkVelodynePacketInterpreter::PushFiringData(unsigned char laserId, unsigned char rawLaserId,
                                                   unsigned short azimuth, double timestamp,
                                                   unsigned int rawtime, const HDLLaserReturn *laserReturn,
                                                   const HDLLaserCorrection *correction, bool isFiringDualReturnData, uint16_t confidence)
 {
-  // Test: filter out all values that are not false returns
-  // "Retro Ghost" is bit (7 + 4) of each confidence value
-  /*if (!((confidence & (1 << 11)) >> 11)) {
-    return;
-  }*/
-
   azimuth %= 36000;
   const vtkIdType thisPointId = this->Points->GetNumberOfPoints();
   short intensity = laserReturn->intensity;
@@ -1034,15 +1025,9 @@ void vtkVelodynePacketInterpreter::PushFiringData(unsigned char laserId, unsigne
   if (this->shouldBeCroppedOut(pos, static_cast<double>(azimuth) / 100.0))
     return;
 
-  /*totalCount++;
-  if (int(totalCount) % 10000 == 0) {
-    std::cout << "total count: " << totalCount << ", test count: " << testCount << ", ratio: " << (testCount/totalCount) << std::endl;
-  }*/
-
   // Do not add any data before here as this might short-circuit
   if (isFiringDualReturnData)
   {
-    //testCount++;
     const vtkIdType dualPointId = this->LastPointId[rawLaserId];
     if (dualPointId < this->FirstPointIdOfDualReturnPair)
     {

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
@@ -1000,6 +1000,12 @@ void vtkVelodynePacketInterpreter::PushFiringData(unsigned char laserId, unsigne
                                                   unsigned int rawtime, const HDLLaserReturn *laserReturn,
                                                   const HDLLaserCorrection *correction, bool isFiringDualReturnData, uint16_t confidence)
 {
+  // Test: filter out all values that are not false returns
+  // "Retro Ghost" is bit (7 + 4) of each confidence value
+  /*if (!((confidence & (1 << 11)) >> 11)) {
+    return;
+  }*/
+
   azimuth %= 36000;
   const vtkIdType thisPointId = this->Points->GetNumberOfPoints();
   short intensity = laserReturn->intensity;

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
@@ -1001,6 +1001,9 @@ void vtkVelodynePacketInterpreter::ProcessFiring(const HDLFiringData *firingData
   }
 }
 
+static double totalCount = 0.0;
+static double testCount = 0.0;
+
 //-----------------------------------------------------------------------------
 void vtkVelodynePacketInterpreter::PushFiringData(unsigned char laserId, unsigned char rawLaserId,
                                                   unsigned short azimuth, double timestamp,
@@ -1031,9 +1034,15 @@ void vtkVelodynePacketInterpreter::PushFiringData(unsigned char laserId, unsigne
   if (this->shouldBeCroppedOut(pos, static_cast<double>(azimuth) / 100.0))
     return;
 
+  totalCount++;
+  if (int(totalCount) % 10000 == 0) {
+    //std::cout << "total count: " << totalCount << ", test count: " << testCount << ", ratio: " << (testCount/totalCount) << std::endl;
+  }
+
   // Do not add any data before here as this might short-circuit
   if (isFiringDualReturnData)
   {
+    testCount++;
     const vtkIdType dualPointId = this->LastPointId[rawLaserId];
     if (dualPointId < this->FirstPointIdOfDualReturnPair)
     {
@@ -1104,7 +1113,6 @@ void vtkVelodynePacketInterpreter::PushFiringData(unsigned char laserId, unsigne
           return;
         }
       }
-
       this->Flags->SetValue(dualPointId, firstFlags);
       this->DistanceFlag->SetValue(dualPointId, MapDistanceFlag(firstFlags));
       this->IntensityFlag->SetValue(dualPointId, MapIntensityFlag(firstFlags));

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
@@ -1508,7 +1508,6 @@ void vtkVelodynePacketInterpreter::PreProcessPacket(unsigned char const * data, 
       isEmptyFrame = false;
     }
 
-    // Do not add confidence blocks if we are in DPC mode
     if (currentFrameState.hasChangedWithValue(firingData))
     {
       // Add file position if the frame is not empty

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
@@ -1477,6 +1477,12 @@ void vtkVelodynePacketInterpreter::PreProcessPacket(unsigned char const * data, 
 
   for (int i = 0; i < HDL_FIRING_PER_PKT; ++i)
   {
+    // Skip confidence blocks of VLS-128 DPC mode
+    if (IsVLS128 && dataPacket->isDPCReturnVLS128() && dataPacket->isConfidenceBlockOfDPCPacket128(i))
+    {
+      continue;
+    }
+
     const HDLFiringData& firingData = dataPacket->firingData[i];
 
     // Skip dummy blocks of VLS-128 dual mode last 4 blocks
@@ -1503,7 +1509,7 @@ void vtkVelodynePacketInterpreter::PreProcessPacket(unsigned char const * data, 
     }
 
     // Do not add confidence blocks if we are in DPC mode
-    if (currentFrameState.hasChangedWithValue(firingData) && !dataPacket->isConfidenceBlockOfDPCPacket128(i))
+    if (currentFrameState.hasChangedWithValue(firingData))
     {
       // Add file position if the frame is not empty
       if (!isEmptyFrame || !this->IgnoreEmptyFrames)

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.h
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.h
@@ -93,7 +93,7 @@ protected:
   // geotransform - georeferencing transform
   void ProcessFiring(const HDLFiringData* firingData,
     int firingBlockLaserOffset, int firingBlock, int azimuthDiff, double timestamp,
-    unsigned int rawtime, bool isThisFiringDualReturnData, bool isDualReturnPacket, uint16_t* confidenceValues);
+    unsigned int rawtime, bool isThisFiringDualReturnData, bool isDualReturnPacket, const std::vector<uint16_t>& confidenceValues);
 
   void PushFiringData(unsigned char laserId, unsigned char rawLaserId,
                       unsigned short azimuth, double timestamp,

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.h
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.h
@@ -93,12 +93,12 @@ protected:
   // geotransform - georeferencing transform
   void ProcessFiring(const HDLFiringData* firingData,
     int firingBlockLaserOffset, int firingBlock, int azimuthDiff, double timestamp,
-    unsigned int rawtime, bool isThisFiringDualReturnData, bool isDualReturnPacket);
+    unsigned int rawtime, bool isThisFiringDualReturnData, bool isDualReturnPacket, uint16_t* confidenceValues);
 
   void PushFiringData(unsigned char laserId, unsigned char rawLaserId,
                       unsigned short azimuth, double timestamp,
                       unsigned int rawtime, const HDLLaserReturn* laserReturn,
-                      const HDLLaserCorrection* correction, bool isFiringDualReturnData);
+                      const HDLLaserCorrection* correction, bool isFiringDualReturnData, uint16_t confidence);
 
   void InitTrigonometricTables();
 
@@ -133,6 +133,7 @@ protected:
   vtkSmartPointer<vtkUnsignedIntArray> Flags;
   vtkSmartPointer<vtkIdTypeArray> DualReturnMatching;
   vtkSmartPointer<vtkDoubleArray> SelectedDualReturn;
+  vtkSmartPointer<vtkUnsignedIntArray> ConfidenceData;
 
   bool ShouldAddDualReturnArray;
 


### PR DESCRIPTION
Parsing dual plus confidence

- Filtering confidence columns in the velodyne packets for point cloud data
- To add support for dual plus confidence
  - We use offsets to map dual plus confidence firing blocks to dual blocks
  - Include dual return parsing for of point cloud data columns
  - Split the confidence bits into confidence for each return

Note: Still working through fixing the accuracy of azimuth and timestamp adjustments within a packet (in progress at separate branch)