### PR TITLE
Timestamp azimuth adjustments

### DIFF
--- a/VelodyneHDL/IO/Lidar/Common/vtkLidarPacketInterpreter.h
+++ b/VelodyneHDL/IO/Lidar/Common/vtkLidarPacketInterpreter.h
@@ -64,8 +64,9 @@ public:
    * @param data raw data packet
    * @param bytesReceived size of the data packet
    * @param startPosition offset in the data packet used when a frame start in the middle of a packet
+   * @param nextData raw next data packet
    */
-  virtual void ProcessPacket(unsigned char const * data, unsigned int dataLength, int startPosition = 0) = 0;
+  virtual void ProcessPacket(unsigned char const * data, unsigned int dataLength, unsigned char const * nextData, int startPosition = 0) = 0;
 
   /**
    * @brief SplitFrame take the current frame under construction and place it in another buffer

--- a/VelodyneHDL/IO/Lidar/Common/vtkLidarPacketInterpreter.h
+++ b/VelodyneHDL/IO/Lidar/Common/vtkLidarPacketInterpreter.h
@@ -56,6 +56,12 @@ public:
   virtual vtkSmartPointer<vtkTable> GetCalibrationTable() { return this->CalibrationData.Get(); }
 
   /**
+   * @brief CopyPacket copies a packet. To interpret a packet, an interpreter may need to know its previous packet
+   * @param data raw data packet
+   */
+  virtual void CopyPacket(unsigned char const * data, unsigned int dataLength) = 0;
+
+  /**
    * @brief ProcessPacket process the data packet to create incrementaly the frame.
    * Each time a packet is processed by the function, the points which are encoded
    * in the packet are decoded using the calibration information and add to the frame. A warning

--- a/VelodyneHDL/IO/Lidar/Common/vtkLidarPacketInterpreter.h
+++ b/VelodyneHDL/IO/Lidar/Common/vtkLidarPacketInterpreter.h
@@ -67,12 +67,11 @@ public:
    * in the packet are decoded using the calibration information and add to the frame. A warning
    * should be raise in case the calibration information does not match the data
    * (ex: factory field, number of laser, ...)
-   * @param data raw data packet
-   * @param bytesReceived size of the data packet
+   * The data packet is now a member variable and is no longer passed to this function.
    * @param startPosition offset in the data packet used when a frame start in the middle of a packet
    * @param nextData raw next data packet
    */
-  virtual void ProcessPacket(unsigned char const * data, unsigned int dataLength, unsigned char const * nextData, int startPosition = 0) = 0;
+  virtual void ProcessPacket(unsigned char const * nextData, int startPosition = 0) = 0;
 
   /**
    * @brief SplitFrame take the current frame under construction and place it in another buffer

--- a/VelodyneHDL/IO/Lidar/Common/vtkLidarPacketInterpreter.h
+++ b/VelodyneHDL/IO/Lidar/Common/vtkLidarPacketInterpreter.h
@@ -184,6 +184,9 @@ public:
 
   vtkSetVector6Macro(CropRegion, double)
 
+  vtkSetMacro(InitProcessedPacket, bool)
+  vtkGetMacro(InitProcessedPacket, bool)
+
   vtkMTimeType GetMTime() override;
 
 protected:
@@ -254,6 +257,8 @@ protected:
   //! - vtkLidarProvider::CropModeEnum::Spherical -> Note implemented yet
   //! all distance are in cm and all angle are in degree
   double CropRegion[6] = {0,0,0,0,0,0};
+
+  bool InitProcessedPacket = false;
 
   vtkLidarPacketInterpreter() = default;
   virtual ~vtkLidarPacketInterpreter() = default;

--- a/VelodyneHDL/IO/Lidar/Common/vtkLidarReader.cxx
+++ b/VelodyneHDL/IO/Lidar/Common/vtkLidarReader.cxx
@@ -155,7 +155,7 @@ vtkSmartPointer<vtkPolyData> vtkLidarReader::GetFrame(int frameNumber)
     return 0;
   }
 
-  const unsigned char* data = 0;
+  const u_char* data = 0;
   unsigned int dataLength = 0;
   double timeSinceStart;
   int firstFramePositionInPacket = this->FilePositions[frameNumber].Skip;
@@ -165,7 +165,7 @@ vtkSmartPointer<vtkPolyData> vtkLidarReader::GetFrame(int frameNumber)
   bool firstRead = this->Reader->NextPacket(data, dataLength, timeSinceStart);
   bool isLidarPacket = this->Interpreter->IsLidarPacket(data, dataLength);
 
-  const unsigned char* nextData = 0;
+  const u_char* nextData = 0;
   unsigned int nextDataLength = 0;
   bool isNextLidarPacket = isLidarPacket;
   while (firstRead && this->Reader->NextPacket(nextData, nextDataLength, timeSinceStart))

--- a/VelodyneHDL/IO/Lidar/Common/vtkLidarReader.cxx
+++ b/VelodyneHDL/IO/Lidar/Common/vtkLidarReader.cxx
@@ -165,6 +165,10 @@ vtkSmartPointer<vtkPolyData> vtkLidarReader::GetFrame(int frameNumber)
   bool firstRead = this->Reader->NextPacket(data, dataLength, timeSinceStart);
   bool isLidarPacket = this->Interpreter->IsLidarPacket(data, dataLength);
 
+  if (isLidarPacket) {
+    this->Interpreter->CopyPacket(data, dataLength);
+  }
+
   const u_char* nextData = 0;
   unsigned int nextDataLength = 0;
   bool isNextLidarPacket = isLidarPacket;
@@ -172,8 +176,7 @@ vtkSmartPointer<vtkPolyData> vtkLidarReader::GetFrame(int frameNumber)
   {
     isLidarPacket = isNextLidarPacket;
     isNextLidarPacket = this->Interpreter->IsLidarPacket(nextData, nextDataLength);
-    if (!isLidarPacket || !isNextLidarPacket)
-    {
+    if (!isLidarPacket || !isNextLidarPacket) {
       continue;
     }
 
@@ -181,8 +184,7 @@ vtkSmartPointer<vtkPolyData> vtkLidarReader::GetFrame(int frameNumber)
     this->Interpreter->SetInitProcessedPacket(true);
 
     // check if the required frames are ready
-    if (this->Interpreter->IsNewFrameReady())
-    {
+    if (this->Interpreter->IsNewFrameReady()) {
       this->Interpreter->SetInitProcessedPacket(false);
       return this->Interpreter->GetLastFrameAvailable();
     }

--- a/VelodyneHDL/IO/Lidar/Common/vtkLidarReader.cxx
+++ b/VelodyneHDL/IO/Lidar/Common/vtkLidarReader.cxx
@@ -180,7 +180,7 @@ vtkSmartPointer<vtkPolyData> vtkLidarReader::GetFrame(int frameNumber)
       continue;
     }
 
-    this->Interpreter->ProcessPacket(data, dataLength, nextData, firstFramePositionInPacket);
+    this->Interpreter->ProcessPacket(nextData, firstFramePositionInPacket);
     this->Interpreter->SetInitProcessedPacket(true);
 
     // check if the required frames are ready
@@ -190,8 +190,10 @@ vtkSmartPointer<vtkPolyData> vtkLidarReader::GetFrame(int frameNumber)
     }
     firstFramePositionInPacket = 0;
 
-    data = nextData;
-    dataLength = nextDataLength;
+    /*data = nextData;
+    dataLength = nextDataLength;*/
+
+    this->Interpreter->CopyPacket(nextData, nextDataLength);
   }
 
   this->Interpreter->SplitFrame(true);

--- a/VelodyneHDL/IO/Lidar/Common/vtkLidarReader.cxx
+++ b/VelodyneHDL/IO/Lidar/Common/vtkLidarReader.cxx
@@ -178,10 +178,12 @@ vtkSmartPointer<vtkPolyData> vtkLidarReader::GetFrame(int frameNumber)
     }
 
     this->Interpreter->ProcessPacket(data, dataLength, nextData, firstFramePositionInPacket);
+    this->Interpreter->SetInitProcessedPacket(true);
 
     // check if the required frames are ready
     if (this->Interpreter->IsNewFrameReady())
     {
+      this->Interpreter->SetInitProcessedPacket(false);
       return this->Interpreter->GetLastFrameAvailable();
     }
     firstFramePositionInPacket = 0;
@@ -191,6 +193,7 @@ vtkSmartPointer<vtkPolyData> vtkLidarReader::GetFrame(int frameNumber)
   }
 
   this->Interpreter->SplitFrame(true);
+  this->Interpreter->SetInitProcessedPacket(false);
   return this->Interpreter->GetLastFrameAvailable();
 }
 

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkDataPacket.h
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkDataPacket.h
@@ -295,7 +295,7 @@ struct HDLDataPacket
   }
 
   // Finds the block index for the start of the current firing sequence
-  inline static int getSeqBlockIndex(const int firingBlock, const int seqLength, const bool isDualReturnPacket)
+  inline static int getSeqBlockIndex(const int firingBlock, const int seqLength)
   {
     return seqLength * (firingBlock / seqLength);
   }

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkDataPacket.h
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkDataPacket.h
@@ -293,6 +293,12 @@ struct HDLDataPacket
         36000);
     }
   }
+
+  // Finds the block index for the start of the current firing sequence
+  inline static int getSeqBlockIndex(const int firingBlock, const int seqLength, const bool isDualReturnPacket)
+  {
+    return seqLength * (firingBlock / seqLength);
+  }
 };
 
 struct HDLLaserCorrection // Internal representation of per-laser correction

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
@@ -962,7 +962,7 @@ void vtkVelodynePacketInterpreter::ProcessFiring(const HDLFiringData *firingData
 
           // Index of column that starts the next firing sequence in single mode
           // Columns 0-3 map to index 4, columns 4-7 map to index 8, columns 8-11 map to index 12
-          int singleNextSeqBlockIndex = currentPacket.getSeqBlockIndex(firingBlock + seqLength, seqLength, isDualReturnPacket);
+          int singleNextSeqBlockIndex = currentPacket.getSeqBlockIndex(firingBlock + seqLength, seqLength);
 
           // For dual/dpc mode and the last firing block of single mode, use timestamp of next packet
           // Otherwise, adjust using the singleNextSeqBlockIndex of this packet
@@ -975,7 +975,7 @@ void vtkVelodynePacketInterpreter::ProcessFiring(const HDLFiringData *firingData
             VLS128AdjustTimeStamp(singleNextSeqBlockIndex, 0, isDualReturnPacket);
 
           // Index of the column that starts this firing sequence in single mode
-          int currentSeqBlockIndex = currentPacket.getSeqBlockIndex(firingBlock, seqLength, isDualReturnPacket);
+          int currentSeqBlockIndex = currentPacket.getSeqBlockIndex(firingBlock, seqLength);
 
           // Index to be used to compute blockdsr0
           // Always 0 for dual mode since we only have one azimuth per packet
@@ -994,7 +994,7 @@ void vtkVelodynePacketInterpreter::ProcessFiring(const HDLFiringData *firingData
 
           // Index of column that starts the next firing sequence
           // Columns 0-3 map to index 4, columns 4-7 map to index 8, columns 8-11 map to index 12
-          int nextSeqBlockIndex = currentPacket.getSeqBlockIndex(firingBlock + seqLength, seqLength, isDualReturnPacket);
+          int nextSeqBlockIndex = currentPacket.getSeqBlockIndex(firingBlock + seqLength, seqLength);
 
           // Use next packet's timestamp for last firing sequence of this packet
           bool shouldUseTimestamp = nextSeqBlockIndex >= HDL_FIRING_PER_PKT;
@@ -1004,7 +1004,7 @@ void vtkVelodynePacketInterpreter::ProcessFiring(const HDLFiringData *firingData
             -HDL64EAdjustTimeStamp(nextSeqBlockIndex, 0, isDualReturnPacket);
 
           // Index of the column that starts this firing sequence
-          int currentSeqBlockIndex = currentPacket.getSeqBlockIndex(firingBlock, seqLength, isDualReturnPacket);
+          int currentSeqBlockIndex = currentPacket.getSeqBlockIndex(firingBlock, seqLength);
 
           blockdsr0 = -HDL64EAdjustTimeStamp(currentSeqBlockIndex, 0, isDualReturnPacket);
           break;

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
@@ -218,7 +218,12 @@ double VLS128AdjustTimeStamp(int firingblock, int dsr, const bool isDualReturnMo
   }
   else
   {
-    return 13.0 * (firingblock / 2) + (dsr / 4) * 1.4;
+    int groupnumber = 4 * (firingblock / 2) + dsr / 8;
+    if (groupnumber <= 7) {
+      return -8.7 + (groupnumber * 2.665);
+    } else {
+      return -8.7 + (groupnumber * 2.665) + 5.33;
+    }
   }
 }
 

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
@@ -723,7 +723,13 @@ void vtkVelodynePacketInterpreter::LoadCalibration(const std::string& filename)
 //-----------------------------------------------------------------------------
 void vtkVelodynePacketInterpreter::ProcessPacket(unsigned char const * data, unsigned int dataLength, unsigned char const * nextData, int startPosition)
 {
-  const HDLDataPacket* dataPacket = reinterpret_cast<const HDLDataPacket*>(data);
+  const HDLDataPacket* dataPacket = prevPacket;
+  if (!InitProcessedPacket) {
+    dataPacket = reinterpret_cast<const HDLDataPacket*>(data);
+  }
+
+  const HDLDataPacket* nextDataPacket = reinterpret_cast<const HDLDataPacket*>(nextData);
+  prevPacket = nextDataPacket;
 
   this->IsHDL64Data |= dataPacket->isHDL64();
 

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
@@ -721,7 +721,7 @@ void vtkVelodynePacketInterpreter::LoadCalibration(const std::string& filename)
 }
 
 //-----------------------------------------------------------------------------
-void vtkVelodynePacketInterpreter::ProcessPacket(unsigned char const * data, unsigned int dataLength, int startPosition)
+void vtkVelodynePacketInterpreter::ProcessPacket(unsigned char const * data, unsigned int dataLength, unsigned char const * nextData, int startPosition)
 {
   if (!this->IsLidarPacket(data, dataLength))
   {

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
@@ -723,11 +723,6 @@ void vtkVelodynePacketInterpreter::LoadCalibration(const std::string& filename)
 //-----------------------------------------------------------------------------
 void vtkVelodynePacketInterpreter::ProcessPacket(unsigned char const * data, unsigned int dataLength, unsigned char const * nextData, int startPosition)
 {
-  if (!this->IsLidarPacket(data, dataLength))
-  {
-    return;
-  }
-
   const HDLDataPacket* dataPacket = reinterpret_cast<const HDLDataPacket*>(data);
 
   this->IsHDL64Data |= dataPacket->isHDL64();

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.cxx
@@ -721,38 +721,38 @@ void vtkVelodynePacketInterpreter::LoadCalibration(const std::string& filename)
 }
 
 //-----------------------------------------------------------------------------
+void vtkVelodynePacketInterpreter::CopyPacket(unsigned char const * data, unsigned int dataLength)
+{
+  std::memcpy(&prevPacket, reinterpret_cast<const HDLDataPacket*>(data), dataLength);
+}
+
+//-----------------------------------------------------------------------------
 void vtkVelodynePacketInterpreter::ProcessPacket(unsigned char const * data, unsigned int dataLength, unsigned char const * nextData, int startPosition)
 {
-  const HDLDataPacket* dataPacket = prevPacket;
-  if (!InitProcessedPacket) {
-    dataPacket = reinterpret_cast<const HDLDataPacket*>(data);
-  }
-
   const HDLDataPacket* nextDataPacket = reinterpret_cast<const HDLDataPacket*>(nextData);
-  prevPacket = nextDataPacket;
 
-  this->IsHDL64Data |= dataPacket->isHDL64();
+  this->IsHDL64Data |= prevPacket.isHDL64();
 
   // Accumulate HDL64 Status byte data
   if (IsHDL64Data && this->IsCorrectionFromLiveStream &&
     !this->IsCalibrated)
   {
-    this->rollingCalibrationData->appendData(dataPacket->gpsTimestamp, dataPacket->factoryField1, dataPacket->factoryField2);
+    this->rollingCalibrationData->appendData(prevPacket.gpsTimestamp, prevPacket.factoryField1, prevPacket.factoryField2);
     this->HDL64LoadCorrectionsFromStreamData();
     return;
   }
 
   if (this->ShouldCheckSensor)
   {
-    this->CheckReportedSensorAndCalibrationFileConsistent(dataPacket);
+    this->CheckReportedSensorAndCalibrationFileConsistent(&prevPacket);
     ShouldCheckSensor = false;
   }
 
-  const unsigned int rawtime = dataPacket->gpsTimestamp;
-  const double timestamp = this->ComputeTimestamp(dataPacket->gpsTimestamp);
+  const unsigned int rawtime = prevPacket.gpsTimestamp;
+  const double timestamp = this->ComputeTimestamp(prevPacket.gpsTimestamp);
 
   // Update the rpm computation (by packets)
-  this->RpmCalculator_->AddData(dataPacket, rawtime);
+  this->RpmCalculator_->AddData(&prevPacket, rawtime);
 
   // Update the transforms here and then call internal
   // transform
@@ -760,7 +760,7 @@ void vtkVelodynePacketInterpreter::ProcessPacket(unsigned char const * data, uns
 
   int firingBlock = startPosition;
 
-  bool isVLS128 = dataPacket->isVLS128();
+  bool isVLS128 = prevPacket.isVLS128();
   // Compute the list of total azimuth advanced during one full firing block
   std::vector<int> diffs(HDL_FIRING_PER_PKT - 1);
   int nonZeroDiff = 0; int localDiff = 0;
@@ -768,11 +768,11 @@ void vtkVelodynePacketInterpreter::ProcessPacket(unsigned char const * data, uns
   {
     if (i == HDL_FIRING_PER_PKT-1) {
       localDiff = (36000 + 18000 + nextDataPacket->firingData[0].rotationalPosition -
-                      dataPacket->firingData[i].rotationalPosition) %
+                      prevPacket.firingData[i].rotationalPosition) %
       36000 - 18000;
     } else {
-      localDiff = (36000 + 18000 + dataPacket->firingData[i + 1].rotationalPosition -
-                      dataPacket->firingData[i].rotationalPosition) %
+      localDiff = (36000 + 18000 + prevPacket.firingData[i + 1].rotationalPosition -
+                      prevPacket.firingData[i].rotationalPosition) %
       36000 - 18000;
     }
 
@@ -784,8 +784,8 @@ void vtkVelodynePacketInterpreter::ProcessPacket(unsigned char const * data, uns
 
   if (!IsHDL64Data)
   { // with HDL64, it should be filled by LoadCorrectionsFromStreamData
-    this->ReportedSensor = dataPacket->getSensorType();
-    this->ReportedSensorReturnMode = dataPacket->getDualReturnSensorMode();
+    this->ReportedSensor = prevPacket.getSensorType();
+    this->ReportedSensorReturnMode = prevPacket.getDualReturnSensorMode();
   }
 
   int firingBlockGroup = HDL_FIRING_PER_PKT / nonZeroDiff;
@@ -807,7 +807,7 @@ void vtkVelodynePacketInterpreter::ProcessPacket(unsigned char const * data, uns
 
   for (; firingBlock < HDL_FIRING_PER_PKT; ++firingBlock)
   {
-    const HDLFiringData* firingData = &(dataPacket->firingData[firingBlock]);
+    const HDLFiringData* firingData = &(prevPacket.firingData[firingBlock]);
     // clang-format off
     int multiBlockLaserIdOffset =
         (firingData->blockIdentifier == BLOCK_0_TO_31)  ?  0 :(
@@ -824,7 +824,7 @@ void vtkVelodynePacketInterpreter::ProcessPacket(unsigned char const * data, uns
     }
 
     // Skip confidence blocks of VLS-128 DPC mode
-    if (isVLS128 && dataPacket->isDPCReturnVLS128() && dataPacket->isConfidenceBlockOfDPCPacket128(firingBlock))
+    if (isVLS128 && prevPacket.isDPCReturnVLS128() && prevPacket.isConfidenceBlockOfDPCPacket128(firingBlock))
     {
       // We will have to adjust for up to 3 confidence blocks per packet
       if (firingBlockDPCAdjustment > 3) {
@@ -834,22 +834,22 @@ void vtkVelodynePacketInterpreter::ProcessPacket(unsigned char const * data, uns
       continue;
     }
 
-    if (isVLS128 && dataPacket->isDPCReturnVLS128() && !dataPacket->isConfidenceBlockOfDPCPacket128(firingBlock))
+    if (isVLS128 && prevPacket.isDPCReturnVLS128() && !prevPacket.isConfidenceBlockOfDPCPacket128(firingBlock))
     {
       // The confidence block is two blocks away from the first firing block, and one block away from the second
-      int offset = dataPacket->isFirstBlockOfDPCPacket128(firingBlock) ? 2 : 1;
+      int offset = prevPacket.isFirstBlockOfDPCPacket128(firingBlock) ? 2 : 1;
 
       for (int laserID = 0; laserID < HDL_LASER_PER_FIRING; ++laserID)
       {
         // First block corresponds to the latter half (12 bits) of confidence data (see VLS-128 manual pg. 59)
-        if (dataPacket->isFirstBlockOfDPCPacket128(firingBlock)) {
+        if (prevPacket.isFirstBlockOfDPCPacket128(firingBlock)) {
           // Select last 4 bits of distance, left shift by 12 bits, then | with 8 bits of intensity left shifted by 4 bits
-          confidenceValues.at(laserID) = (dataPacket->firingData[firingBlock + offset].laserReturns[laserID].distance & 0x000f << 12) |
-              dataPacket->firingData[firingBlock + offset].laserReturns[laserID].intensity << 4;
+          confidenceValues.at(laserID) = (prevPacket.firingData[firingBlock + offset].laserReturns[laserID].distance & 0x000f << 12) |
+              prevPacket.firingData[firingBlock + offset].laserReturns[laserID].intensity << 4;
         }
-        else if (dataPacket->isSecondBlockOfDPCPacket128(firingBlock)) {
+        else if (prevPacket.isSecondBlockOfDPCPacket128(firingBlock)) {
           // Second firing block confidence data is the first 12 bits of distance
-          confidenceValues.at(laserID) = dataPacket->firingData[firingBlock + offset].laserReturns[laserID].distance & 0xfff0;
+          confidenceValues.at(laserID) = prevPacket.firingData[firingBlock + offset].laserReturns[laserID].distance & 0xfff0;
         }
         else {
           std::cout << "Warning: confidence not being set" << std::endl;
@@ -876,7 +876,7 @@ void vtkVelodynePacketInterpreter::ProcessPacket(unsigned char const * data, uns
     if (this->FiringsSkip == 0 || (firingBlock - firingBlockDPCAdjustment) % (this->FiringsSkip + 1) == 0)
     {
       this->ProcessFiring(firingData, multiBlockLaserIdOffset, firingBlock - firingBlockDPCAdjustment, azimuthDiff, timestamp,
-        rawtime, dataPacket->isDualReturnFiringBlock(firingBlock), dataPacket->isDualModeReturn() || dataPacket->isDPCReturnVLS128(), confidenceValues);
+        rawtime, prevPacket.isDualReturnFiringBlock(firingBlock), prevPacket.isDualModeReturn() || prevPacket.isDPCReturnVLS128(), confidenceValues);
     }
   }
 }

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.h
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.h
@@ -36,7 +36,7 @@ public:
 
   void CopyPacket(unsigned char const * data, unsigned int dataLength) override;
 
-  void ProcessPacket(unsigned char const * data, unsigned int dataLength, unsigned char const * nextData, int startPosition = 0) override;
+  void ProcessPacket(unsigned char const * nextData, int startPosition = 0) override;
 
   bool SplitFrame(bool force = false) override;
 
@@ -197,7 +197,7 @@ protected:
 
   bool ShouldValidateCalibrationFromStream = true;
 
-  HDLDataPacket prevPacket;
+  HDLDataPacket currentPacket;
 
   vtkVelodynePacketInterpreter();
   ~vtkVelodynePacketInterpreter();

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.h
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.h
@@ -34,6 +34,8 @@ public:
 
   void LoadCalibration(const std::string& filename) override;
 
+  void CopyPacket(unsigned char const * data, unsigned int dataLength) override;
+
   void ProcessPacket(unsigned char const * data, unsigned int dataLength, unsigned char const * nextData, int startPosition = 0) override;
 
   bool SplitFrame(bool force = false) override;
@@ -195,7 +197,7 @@ protected:
 
   bool ShouldValidateCalibrationFromStream = true;
 
-  const HDLDataPacket* prevPacket;
+  HDLDataPacket prevPacket;
 
   vtkVelodynePacketInterpreter();
   ~vtkVelodynePacketInterpreter();

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.h
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.h
@@ -34,7 +34,7 @@ public:
 
   void LoadCalibration(const std::string& filename) override;
 
-  void ProcessPacket(unsigned char const * data, unsigned int dataLength, int startPosition = 0) override;
+  void ProcessPacket(unsigned char const * data, unsigned int dataLength, unsigned char const * nextData, int startPosition = 0) override;
 
   bool SplitFrame(bool force = false) override;
 

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.h
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.h
@@ -94,7 +94,7 @@ protected:
   // timestamp - the timestamp of the packet
   // geotransform - georeferencing transform
   void ProcessFiring(const HDLFiringData* firingData,
-    int firingBlockLaserOffset, int firingBlock, int azimuthDiff, double timestamp,
+    int firingBlockLaserOffset, int firingBlock, int azimuthDiff, double timestamp, double nextTimestamp,
     unsigned int rawtime, bool isThisFiringDualReturnData, bool isDualReturnPacket, const std::vector<uint16_t>& confidenceValues);
 
   void PushFiringData(unsigned char laserId, unsigned char rawLaserId,

--- a/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.h
+++ b/VelodyneHDL/IO/Lidar/Velodyne/vtkVelodynePacketInterpreter.h
@@ -195,6 +195,8 @@ protected:
 
   bool ShouldValidateCalibrationFromStream = true;
 
+  const HDLDataPacket* prevPacket;
+
   vtkVelodynePacketInterpreter();
   ~vtkVelodynePacketInterpreter();
 


### PR DESCRIPTION
- Using the following packet's timestamp to compute azimuth adjustments for the current packet.
- For 128 single and 64 dual modes, we only use the following packet's timestamp for the last of three firing sequences per packet. If I were to redo this, I would use the next timestamp for all firing sequences, in order to spread out any timing irregularity across the entire packet. In practice, this makes no difference as far as I can tell - interpolated and measured times differ by a few microseconds.
- For 128 dual and dual plus confidence, corrections are now being applied where previously the corrections were all zero.