### PR TITLE
Fixed broken submodule pointer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "TestData"]
-	path = TestData
-	url = ../VeloView-TestData.git
 [submodule "Superbuild/common-superbuild"]
 	path = Superbuild/common-superbuild
 	url = https://gitlab.kitware.com/paraview/common-superbuild


### PR DESCRIPTION
Removes a broken submodule pointer to `VeloView-TestData` in our fork of VeloView. See [LogParser#80](https://app.zenhub.com/workspaces/veritas-5b9aa680dfeccd3433cd6f62/issues/nextdroid/logparser/80)