### PR TITLE
putting superbuild back

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Superbuild/common-superbuild"]
+	path = Superbuild/common-superbuild
+	url = https://gitlab.kitware.com/paraview/common-superbuild


### PR DESCRIPTION
I misunderstood the need for this repo. We're not really sure how important it is. Knowing (or not knowing) that info, I think that is enough to want to avoid any complications in removing it.

Unfortunately, this means that building Veritas in AWS CodeBuild is too complicated to continue. Superbuild is just some repo in someone's enterprise gitlab. So, CodeCommit refuses to connect to it (it will only connect to a handful of git systems).

I'll continue building locally for now - it's just simpler than anything we would need to do in CodeCommit.

There is no urgency in merging this: currently Veritas/develop points to a LogParser which points to a VeloView that HAS superbuild.    