### PR TITLE
Merge arjun/last-frame-only-one-packet onto develop

### DIFF
--- a/VelodyneHDL/IO/Lidar/Common/vtkLidarReader.h
+++ b/VelodyneHDL/IO/Lidar/Common/vtkLidarReader.h
@@ -44,7 +44,7 @@ public:
    * @brief GetFrame returns the requested frame
    * @param frameNumber beteween 0 and vtkLidarReader::GetNumberOfFrames()
    */
-  virtual vtkSmartPointer<vtkPolyData> GetFrame(int frameNumber);
+  virtual vtkSmartPointer<vtkPolyData> GetFrame(int frameNumber, int numFrames);
 
   /**
    * @brief Open open the pcap file


### PR DESCRIPTION
A better solution to this: https://github.com/NextDroid/LogParser/pull/113

The last frame is not the problem generally. It is only if the last frame only is a packet. So we detect it now, Log it and handle it so that we don't crash. 